### PR TITLE
Eslint configuration (Atom)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 1. [Julia](#julia)
 2. [JavaScript](#javascript_react)
-  * [ESLint](#eslint)
+  ..* [ESLint](#eslint)
 
 ## Julia
 In general, follow the conventions of the [Julia language authors](http://docs.julialang.org/en/release-0.5/manual/style-guide/).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Style guideline for different languages used at BCBI
 
 1. [Julia](#julia)
-2. [JavaScript](#javascript_react)
+2. [JavaScript](#javascript--react)
+3. [ESLint](#eslint)
 
 ## Julia
 In general, follow the conventions of the [Julia language authors](http://docs.julialang.org/en/release-0.5/manual/style-guide/).
-    
+
 * Naming:
   * Use PascalCase for Modules and main module filename. E.g., MultivariateStats.jl
   * Use snake_case for variable and function names, as well as any other filename besides the main module file
@@ -18,7 +19,7 @@ In general, follow the conventions of the [Julia language authors](http://docs.j
 
 ## JavaScript - React
 
-* For JSX style, follow [Airbnb guidelines](https://github.com/airbnb/javascript/tree/master/react) 
+* For JSX style, follow [Airbnb guidelines](https://github.com/airbnb/javascript/tree/master/react)
 * Folder organization for a react-redux app is inspired on this [post](https://www.robinwieruch.de/tips-to-learn-react-redux/#folderOrganization). Depending on the leavel of complexity of your app, it may look something like
 
 ### For smaller projects:
@@ -53,3 +54,60 @@ src/
 ----spec.js (tests)
 ```
 
+<a name="eslint"/>
+### ESLint installation (Atom)
+</a>
+
+Install linter-eslint through the atom package manager or the console.
+
+```console
+apm install linter-eslint
+```
+Install `eslint` and the relevant plugins to your local project (Airbnb eslint configurations).
+
+```console
+npm i --save-dev eslint
+```
+
+Follow npm instructions to install peer dependencies for eslint-config-airbnb. https://www.npmjs.com/package/eslint-config-airbnb
+
+Create a `.eslintrc` configuration file.
+
+```console
+eslint init
+```
+
+Sample `.eslintrc` file (in JSON format) from Ligercat:
+
+```json
+{
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true
+  },
+  "extends": [
+    "airbnb",
+    "plugin:react/recommended",
+    "eslint:recommended"
+  ],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
+      "jsx": true
+    },
+    "sourceType": "module"
+  },
+  "plugins": [
+    "react"
+  ],
+  "rules": {
+    "no-console": 0,
+    "import/no-named-default": 0
+  }
+}
+```
+
+Each rule can be toggled on or off (off denoted by a 0). Refer to each plugin's documentation for info regarding values that the rule can take on.
+
+Note from the npm installation instructions that `"extends": "airbnb"` must be included the `.eslintrc` to enforce airbnb code styles. In the case of Ligercat, some recommended rules from the react plugin and eslint were also 'extended'.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 1. [Julia](#julia)
 2. [JavaScript](#javascript_react)
-3. [ESLint](#eslint)
+  * [ESLint](#eslint)
 
 ## Julia
 In general, follow the conventions of the [Julia language authors](http://docs.julialang.org/en/release-0.5/manual/style-guide/).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Style guideline for different languages used at BCBI
 
 1. [Julia](#julia)
-2. [JavaScript](#javascript--react)
+2. [JavaScript](#javascript_react)
 3. [ESLint](#eslint)
 
 ## Julia
@@ -17,6 +17,7 @@ In general, follow the conventions of the [Julia language authors](http://docs.j
 * Other:
   * Append the `!` symbol to the names of functions that modify their arguments. Good examples from the core language are `push!()` and `append!()`.
 
+<a name="javascript_react"/></a>
 ## JavaScript - React
 
 * For JSX style, follow [Airbnb guidelines](https://github.com/airbnb/javascript/tree/master/react)
@@ -54,9 +55,9 @@ src/
 ----spec.js (tests)
 ```
 
-<a name="eslint"/>
+<a name="eslint"/></a>
 ### ESLint installation (Atom)
-</a>
+
 
 Install linter-eslint through the atom package manager or the console.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 1. [Julia](#julia)
 2. [JavaScript](#javascript_react)
-  ..* [ESLint](#eslint)
+3. [ESLint](#eslint)
 
 ## Julia
 In general, follow the conventions of the [Julia language authors](http://docs.julialang.org/en/release-0.5/manual/style-guide/).


### PR DESCRIPTION
Added a subsection to Javascript for eslint. I described how I set up the linter in the Atom text editor for use in Ligercat, and thought this would be useful as a reference for other projects. Perhaps we could also compile a list of errors commonly run into when configuring linters.